### PR TITLE
Exclude compare tasks from the concurrency limit

### DIFF
--- a/src/cli/test.js
+++ b/src/cli/test.js
@@ -12,20 +12,21 @@ module.exports = function test (config, argv) {
 
   const captureOpts = pick(['ignoreSelectors', 'renderWaitTime'], config)
   const testPairs = chunk(2, testPermutations(config))
-  const diffs = []
+  const diffPs = []
 
   testPairs.forEach(pair => {
     q.push(cb => {
       capturePair(pair, captureOpts)
-        .then(diffCaptures)
-        .then(diff => cb(null, diff))
+        .then(captures => cb(null, captures))
     })
   })
 
-  q.on('success', res => diffs.push(res))
+  q.on('success', captures => diffPs.push(diffCaptures(captures)))
 
   return new Promise(resolve =>
-    q.start(() => resolve(diffs))
+    q.start(() =>
+      Promise.all(diffPs).then(diffs => resolve(diffs))
+    )
   )
 }
 


### PR DESCRIPTION
Previously, capture and compare were treated as a single task on the queue. A new capture/compare task could only be started when a previous task had completed. This change makes it so that captures can run independently of the queue, which allows more captures to happen concurrently. In my tests, this resulted in a 5-15% speedup of the overall test command.