### PR TITLE
Revert "Exclude compare tasks from the concurrency limit"

### DIFF
--- a/src/cli/test.js
+++ b/src/cli/test.js
@@ -12,21 +12,20 @@ module.exports = function test (config, argv) {
 
   const captureOpts = pick(['ignoreSelectors', 'renderWaitTime'], config)
   const testPairs = chunk(2, testPermutations(config))
-  const diffPs = []
+  const diffs = []
 
   testPairs.forEach(pair => {
     q.push(cb => {
       capturePair(pair, captureOpts)
-        .then(captures => cb(null, captures))
+        .then(diffCaptures)
+        .then(diff => cb(null, diff))
     })
   })
 
-  q.on('success', captures => diffPs.push(diffCaptures(captures)))
+  q.on('success', res => diffs.push(res))
 
   return new Promise(resolve =>
-    q.start(() =>
-      Promise.all(diffPs).then(diffs => resolve(diffs))
-    )
+    q.start(() => resolve(diffs))
   )
 }
 


### PR DESCRIPTION
Reverts wildlyinaccurate/whoopsie#30

This change caused a huge spike in `convert` errors on the BBC News test suite. Not sure what exactly is causing this, but v0.5.1 does not have the issue.

```
Unhandled rejection convert: geometry does not contain image `/tmp/magick-258FMdreafJi5QN' @ warning/attribute.c/GetImageBoundingBox/247.
```