### PR TITLE
Add support for "selectors" in each page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,49 +73,81 @@ Outputs test results as JSON.
     "results": [
         {
             "base": {
-                "id": "capture$af47bcbd",
-                "url": "http://www.bbc.com/news/",
-                "imagePath": "/tmp/whoopsie-capture$af47bcbd.png"
+                "type": "selector",
+                "selector": ".nw-c-top-stories",
+                "id": "capture$ad367858",
+                "page": {
+                    "path": "/news",
+                    "selectors": [
+                        ".nw-c-top-stories",
+                        ".nw-c-must-see"
+                    ],
+                    "url": "http://www.bbc.com/news"
+                },
+                "imagePath": "/tmp/whoopsie-capture$ad367858-0.png"
             },
             "test": {
-                "id": "capture$50380d46",
-                "url": "http://www.test.bbc.com/news/",
-                "imagePath": "/tmp/whoopsie-capture$50380d46.png"
+                "type": "selector",
+                "selector": ".nw-c-top-stories",
+                "id": "capture$c1dbebb0",
+                "page": {
+                    "path": "/news",
+                    "selectors": [
+                        ".nw-c-top-stories",
+                        ".nw-c-must-see"
+                    ],
+                    "url": "http://www.test.bbc.com/news"
+                },
+                "imagePath": "/tmp/whoopsie-capture$c1dbebb0-0.png"
             },
             "diff": {
                 "total": 0,
                 "percentage": 0,
-                "id": "compare$48c4c849",
-                "imagePath": "/tmp/whoopsie-compare$48c4c849.png"
+                "id": "compare$520b7196",
+                "imagePath": "/tmp/whoopsie-compare$520b7196.png"
             },
             "viewport": {
-                "width": 320,
-                "height": 480,
-                "isMobile": true,
-                "javascriptDisabled": true,
-                "name": "Core Experience"
+                "width": 640,
+                "isMobile": true
             }
         },
         {
             "base": {
-                "id": "capture$a82dce5a",
-                "url": "http://www.bbc.com/news/",
-                "imagePath": "/tmp/whoopsie-capture$a82dce5a.png"
+                "type": "selector",
+                "selector": ".nw-c-must-see",
+                "id": "capture$ad367858",
+                "page": {
+                    "path": "/news",
+                    "selectors": [
+                        ".nw-c-top-stories",
+                        ".nw-c-must-see"
+                    ],
+                    "url": "http://www.bbc.com/news"
+                },
+                "imagePath": "/tmp/whoopsie-capture$ad367858-1.png"
             },
             "test": {
-                "id": "capture$a0854fc8",
-                "url": "http://www.test.bbc.com/news/",
-                "imagePath": "/tmp/whoopsie-capture$a0854fc8.png"
+                "type": "selector",
+                "selector": ".nw-c-must-see",
+                "id": "capture$c1dbebb0",
+                "page": {
+                    "path": "/news",
+                    "selectors": [
+                        ".nw-c-top-stories",
+                        ".nw-c-must-see"
+                    ],
+                    "url": "http://www.test.bbc.com/news"
+                },
+                "imagePath": "/tmp/whoopsie-capture$c1dbebb0-1.png"
             },
             "diff": {
-                "total": 4750.12,
-                "percentage": 0.0724822,
-                "id": "compare$33624d4c",
-                "imagePath": "/tmp/whoopsie-compare$33624d4c.png"
+                "total": 0,
+                "percentage": 0,
+                "id": "compare$2a2e5a47",
+                "imagePath": "/tmp/whoopsie-compare$2a2e5a47.png"
             },
             "viewport": {
-                "width": 320,
-                "height": 480,
+                "width": 640,
                 "isMobile": true
             }
         }

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -3,6 +3,21 @@ sites:
   - http://www.bbc.com
   - http://www.test.bbc.com
 
+# List of pages to test on each site
+pages:
+  # Each page must have a path (relative to the site URLs).
+  # By default, the whole page will be captured.
+  - path: /news
+
+  # Pages can also have a list of selectors. Rather than capturing the whole
+  # page, an image of each selector will be captured.
+  - path: /news
+    selectors:
+      - .nw-c-top-stories
+      - .nw-c-must-see
+      - .nw-c-full-story
+      - .nw-c-most-read
+
 # Viewport configurations to run tests with
 # Each viewport can have the following properties:
 #  - width (required)
@@ -10,10 +25,8 @@ sites:
 #  - isMobile (default: false)
 #  - javascriptDisabled (default: false)
 #  - name
-#
 viewports:
-  - width: 320
-    height: 480
+  - width: 640
     isMobile: true
 
   - width: 320
@@ -22,13 +35,8 @@ viewports:
     javascriptDisabled: true
     name: Core Experience
 
-# List of paths to test (relative to site URLs)
-paths:
-  - /news
-
 # Which browser to run the tests with. Available browsers:
 #  - HeadlessChrome
-#
 browser: HeadlessChrome
 
 # List of requests to block.
@@ -42,10 +50,8 @@ ignoreSelectors:
   - '#blq-global'
   - '#orb-header'
   - '#orb-footer'
+  - '.nw-c-breaking-news-banner'
   - '#breaking-news-container'
-
-# Directory in which to save test results
-galleryDir: results/
 
 # How different two pages should be (as a percentage) for a test to fail
 failureThreshold: 10

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -3,7 +3,7 @@ const config = require('../src/config')
 const minimumValidConfig = {
   sites: ['site1', 'site2'],
   viewports: [{ width: 200 }, { width: 300 }],
-  paths: ['/']
+  pages: [{ path: '/' }]
 }
 
 describe('config.processFile()', () => {
@@ -46,8 +46,8 @@ describe('config.process()', () => {
     config.process(modifyConfig({ viewports: [] })).catch(done)
   })
 
-  it('should reject config with no paths', done => {
-    config.process(modifyConfig({ paths: [] })).catch(done)
+  it('should reject config with no pages', done => {
+    config.process(modifyConfig({ pages: [] })).catch(done)
   })
 
   it('should accept a config with optional values', done => {

--- a/spec/support/invalid-config.yaml
+++ b/spec/support/invalid-config.yaml
@@ -1,14 +1,14 @@
 sites:
   - http://www.bbc.co.uk/news
 
+pages:
+  - path: /
+  - path: /technology
+  - path: /technology-36387563
+
 widths:
   - 320
   - 600
-
-paths:
-  - /
-  - /technology
-  - /technology-36387563
 
 ignoreSelectors:
 

--- a/spec/support/test-config.yaml
+++ b/spec/support/test-config.yaml
@@ -2,12 +2,12 @@ sites:
   - http://localhost:8888/1
   - http://localhost:8888/2
 
+pages:
+  - path: .html
+
 viewports:
   - width: 240
   - width: 320
-
-paths:
-  - .html
 
 renderWaitTime: 0
 galleryDir: results/

--- a/spec/test-permutations-spec.js
+++ b/spec/test-permutations-spec.js
@@ -3,28 +3,34 @@ const testPermutations = require('../src/test-permutations')
 describe('testPermutations()', () => {
   it('should generate (url, width) tuples', () => {
     const sites = ['http://site-1', 'http://site-2']
-    const paths = ['/test-page']
+    const pages = [{ path: '/test-page' }]
     const widths = [100, 200]
 
-    expect(testPermutations(sites, paths, widths)).toEqual([
-      [['http://site-1/test-page', 100], ['http://site-2/test-page', 100]],
-      [['http://site-1/test-page', 200], ['http://site-2/test-page', 200]]
+    expect(testPermutations(sites, pages, widths)).toEqual([
+      [
+        [{ path: '/test-page', url: 'http://site-1/test-page' }, 100],
+        [{ path: '/test-page', url: 'http://site-2/test-page' }, 100]
+      ],
+      [
+        [{ path: '/test-page', url: 'http://site-1/test-page' }, 200],
+        [{ path: '/test-page', url: 'http://site-2/test-page' }, 200]
+      ]
     ])
   })
 
-  it('should allow query parameters and ports in both sites and paths', () => {
-    const sites = ['http://site:8080?env=test', 'http://site?env=live']
-    const paths = ['/test-page?other-param=true']
+  it('should allow query parameters and ports in both sites and pages', () => {
+    const sites = ['http://site?env=test', 'http://site?env=live']
+    const pages = [{ path: '/☃️?p=1' }]
     const widths = [100, 200]
 
-    expect(testPermutations(sites, paths, widths)).toEqual([
+    expect(testPermutations(sites, pages, widths)).toEqual([
       [
-        ['http://site:8080/test-page?env=test&other-param=true', 100],
-        ['http://site/test-page?env=live&other-param=true', 100]
+        [{ path: '/☃️?p=1', url: 'http://site/☃️?env=test&p=1' }, 100],
+        [{ path: '/☃️?p=1', url: 'http://site/☃️?env=live&p=1' }, 100]
       ],
       [
-        ['http://site:8080/test-page?env=test&other-param=true', 200],
-        ['http://site/test-page?env=live&other-param=true', 200]
+        [{ path: '/☃️?p=1', url: 'http://site/☃️?env=test&p=1' }, 200],
+        [{ path: '/☃️?p=1', url: 'http://site/☃️?env=live&p=1' }, 200]
       ]
     ])
   })

--- a/src/capture.js
+++ b/src/capture.js
@@ -3,25 +3,59 @@ const os = require('os')
 const log = require('./log')
 const identifier = require('./identifier')
 
-module.exports = async function capture (driver, url, viewport, config) {
+module.exports = async function capture (driver, page, viewport, config) {
   const { width } = viewport
   const captureId = identifier('capture')
 
-  log.info(`Capturing ${url} at ${width}px`)
+  log.info(`Capturing ${page.url} at ${width}px`)
   log.debug(`Capture identifier is ${captureId}`)
   log.time(captureId)
 
-  const imagePath = path.join(os.tmpdir(), `whoopsie-${captureId}.png`)
-
-  await driver.capture(imagePath, url, viewport, config)
+  const results = await doCapture(driver, captureId, page, viewport, config)
 
   log.timeEnd(captureId)
 
-  return new CaptureResult(captureId, url, imagePath)
+  return results
 }
 
-function CaptureResult (id, url, imagePath) {
+async function doCapture (driver, captureId, page, viewport, config) {
+  if (page.selectors) {
+    const results = page.selectors.map(
+      (selector, index) =>
+        new SelectorCaptureResult(
+          selector,
+          captureId,
+          page,
+          makeImagePath(`${captureId}-${index}`)
+        )
+    )
+
+    await driver.captureSelectors(results, page.url, viewport, config)
+
+    return results
+  } else {
+    const imagePath = makeImagePath(captureId)
+    await driver.capturePage(imagePath, page.url, viewport, config)
+
+    return [new PageCaptureResult(captureId, page, imagePath)]
+  }
+}
+
+function makeImagePath (suffix) {
+  return path.join(os.tmpdir(), `whoopsie-${suffix}.png`)
+}
+
+function PageCaptureResult (id, page, imagePath) {
+  this.type = 'page'
   this.id = id
-  this.url = url
+  this.page = page
+  this.imagePath = imagePath
+}
+
+function SelectorCaptureResult (selector, id, page, imagePath) {
+  this.type = 'selector'
+  this.selector = selector
+  this.id = id
+  this.page = page
   this.imagePath = imagePath
 }

--- a/src/compare.js
+++ b/src/compare.js
@@ -4,10 +4,20 @@ const diff = Promise.promisify(require('image-diff').getFullResult)
 const log = require('./log')
 const identifier = require('./identifier')
 
-module.exports = function compare (baseCapture, testCapture) {
+// compareCaptures :: [CaptureResult] -> [CaptureResult] -> [CompareResult]
+module.exports = function compareCaptures (baseCaptures, testCaptures) {
+  return Promise.all(
+    baseCaptures.map((base, index) => compare(base, testCaptures[index]))
+  )
+}
+
+// compare :: CaptureResult -> CaptureResult -> CompareResult
+function compare (baseCapture, testCapture) {
   const compareId = identifier('compare')
 
-  log.info(`Comparing captures of ${baseCapture.url} and ${testCapture.url}`)
+  log.info(
+    `Comparing captures of ${baseCapture.page.url} and ${testCapture.page.url}`
+  )
   log.debug(`Compare identifier is ${compareId}`)
   log.time(compareId)
 
@@ -27,7 +37,7 @@ module.exports = function compare (baseCapture, testCapture) {
       results.id = compareId
       results.imagePath = diffImagePath
 
-      return new Diff(results, baseCapture, testCapture)
+      return new CompareResult(results, baseCapture, testCapture)
     })
     .catch(error => {
       log.error(
@@ -37,7 +47,7 @@ module.exports = function compare (baseCapture, testCapture) {
     })
 }
 
-function Diff (diff, baseCapture, testCapture) {
+function CompareResult (diff, baseCapture, testCapture) {
   this.base = baseCapture
   this.test = testCapture
   this.diff = diff

--- a/src/config.js
+++ b/src/config.js
@@ -60,11 +60,11 @@ function makeSchema () {
       }
     ],
 
-    paths: {
+    pages: {
       type: 'array',
       required: true,
       use: x => x.length > 0,
-      message: 'At least one "paths" value must be specified'
+      message: 'At least one "pages" value must be specified'
     },
 
     blockRequests: {

--- a/src/test-permutations.js
+++ b/src/test-permutations.js
@@ -1,5 +1,5 @@
 const { format, parse } = require('url')
-const { chunk, merge } = require('lodash/fp')
+const { chunk, merge, set } = require('lodash/fp')
 const product = require('cartesian-product')
 
 // Generate a list of pairs which contain (url, viewport) tuples representing all
@@ -7,21 +7,21 @@ const product = require('cartesian-product')
 //
 // The permutations will be ordered such that each pair contains the same url
 // and viewport for each site.
-module.exports = function testPermutations (sites, paths, viewports) {
+module.exports = function testPermutations (sites, pages, viewports) {
   const pairs = chunk(2)
 
-  return pairs(product([paths, viewports, sites]).map(makeTuple))
+  return pairs(product([pages, viewports, sites]).map(makeTuple))
 }
 
-function makeTuple ([path, viewport, site]) {
+function makeTuple ([page, viewport, site]) {
   const siteUrl = parse(site, true)
-  const pathUrl = parse(path, true)
+  const pathUrl = parse(page.path, true)
 
   siteUrl.pathname = mergePathnames(siteUrl.pathname, pathUrl.pathname)
   siteUrl.query = merge(siteUrl.query, pathUrl.query)
   siteUrl.search = undefined
 
-  return [format(siteUrl), viewport]
+  return [set('url', format(siteUrl), page), viewport]
 }
 
 function mergePathnames (path1, path2) {

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -52,13 +52,13 @@
         <div class="pure-g">
             <div class="pure-u-1-3 p-1">
                 <h3>
-                    <%= result.base.url %> (<%= result.viewport.name ? result.viewport.name : result.viewport.width + 'px' %>)
+                    <%= result.base.page.url %> (<%= result.viewport.name ? result.viewport.name : result.viewport.width + 'px' %>)
                 </h3>
             </div>
 
             <div class="pure-u-1-3 p-1">
                 <h3>
-                    <%= result.test.url %> (<%= result.viewport.name ? result.viewport.name : result.viewport.width + 'px' %>)
+                    <%= result.test.page.url %> (<%= result.viewport.name ? result.viewport.name : result.viewport.width + 'px' %>)
                 </h3>
             </div>
 


### PR DESCRIPTION
The main part of the config is now

```yaml
# Two URLs to run tests against. The first is considered to be the baseline
sites:
  - http://www.bbc.com
  - http://www.test.bbc.com

# List of pages to test on each site
pages:
  # Each page must have a path (relative to the site URLs).
  # By default, the whole page will be captured.
  - path: /news

  # Pages can also have a list of selectors. Rather than capturing the whole
  # page, an image of each selector will be captured.
  - path: /news
    selectors:
      - .nw-c-top-stories
      - .nw-c-must-see
      - .nw-c-full-story
      - .nw-c-most-read
```